### PR TITLE
raise ResponseNotReady on match

### DIFF
--- a/helga_bugzilla.py
+++ b/helga_bugzilla.py
@@ -1,7 +1,7 @@
 from txbugzilla import connect
 from twisted.internet import defer
 import re
-from helga.plugins import match
+from helga.plugins import match, ResponseNotReady
 from helga import log, settings
 
 logger = log.getLogger(__name__)
@@ -46,6 +46,7 @@ def helga_bugzilla(client, channel, nick, message, matches):
     # TODO: make this second callback not fire, if errback was called.
     d.addCallback(send_message, client, channel, nick)
     d.addErrback(send_err, client, channel)
+    raise ResponseNotReady
 
 
 @defer.inlineCallbacks


### PR DESCRIPTION
With the big async rewrite(s), we now have the following problem where both the Redmine and Bugzilla plugins are triggering on "bug":

```
< ktdreyer>: bug 1
< kraken>: ktdreyer might be talking about https://bugzilla.redhat.com/1 [please DO NOT use this bug for testing]
< kraken>: ktdreyer might be talking about http://tracker.ceph.com/issues/1 [gpf in tcp_sendpage]
```

Fixes #1 