### PR TITLE
split construct_message() into describe_bugs()

### DIFF
--- a/helga_bugzilla.py
+++ b/helga_bugzilla.py
@@ -62,6 +62,14 @@ def construct_message(bugs, nick):
     """
     Return a string about a nick and a list of tickets' URLs and summaries.
     """
+    description = describe_bugs(bugs)
+    return '%s might be talking about %s' % (nick, description)
+
+
+def describe_bugs(bugs):
+    """
+    Return a string that describes a set of bugs (one, or more than one, etc)
+    """
     msgs = []
     for bug in bugs:
         if hasattr(settings, 'BUGZILLA_TICKET_URL'):
@@ -70,10 +78,9 @@ def construct_message(bugs, nick):
             url = bug.weburl
         msgs.append('%s [%s]' % (url, bug.summary))
     if len(msgs) == 1:
-        msg = msgs[0]
+        return msgs[0]
     else:
-        msg = "{} and {}".format(", ".join(msgs[:-1]), msgs[-1])
-    return '%s might be talking about %s' % (nick, msg)
+        return "{} and {}".format(", ".join(msgs[:-1]), msgs[-1])
 
 
 def send_message(bugs, client, channel, nick):


### PR DESCRIPTION
Split out the code that describes a list of bugs into its own method.

This will allow us to use `describe_bugs()` in more ways than simple BZ number matching.