### PR TITLE
split actions into separate libs

### DIFF
--- a/helga_bugzilla/__init__.py
+++ b/helga_bugzilla/__init__.py
@@ -1,85 +1,33 @@
 from txbugzilla import connect
-from twisted.internet import defer
-import re
 from helga.plugins import match, ResponseNotReady
 from helga import log, settings
+from helga_bugzilla.actions import describe
 
 logger = log.getLogger(__name__)
 
 
-def match_tickets(message):
-    tickets = []
-
-    pattern = re.compile(r"""
-       (?:               # Prefix to trigger the plugin:
-            bzs?         #   "bz" or "bzs"
-          | bugs?        #   "bug" or "bugs"
-          | bugzilla?    #   "bugzilla" or "bugzillas"
-       )                 #
-       \s*               #
-       [#]?[0-9]+        # Number, optionally preceded by "#"
-       (?:               # The following pattern will match zero or more times:
-          ,?             #   Optional comma
-          \s+            #
-          (?:and\s+)?    #   Optional "and "
-          [#]?[0-9]+     #   Number, optionally preceded by "#"
-       )*
-       """, re.VERBOSE | re.IGNORECASE)
-    for bzmatch in re.findall(pattern, message):
-        for ticket in re.findall(r'[0-9]+', bzmatch):
-            if ticket == '2' and 'bz2' in bzmatch:
-                continue  # False positive, like ".tar.bz2".
-            if ticket not in tickets:
-                tickets.append(ticket)
-    return tickets
+def match_bugzilla(message):
+    for action in (describe,):
+        matches = action.match(message)
+        if matches:
+            return (action, matches)
 
 
-@match(match_tickets, priority=0)
-def helga_bugzilla(client, channel, nick, message, matches):
+@match(match_bugzilla, priority=0)
+def helga_bugzilla(client, channel, nick, message, action_and_matches):
     """
-    Match possible Bugzilla tickets, return links and summary info
+    Match information related to Bugzilla.
     """
     connect_args = {}
     if hasattr(settings, 'BUGZILLA_XMLRPC_URL'):
         connect_args['url'] = settings.BUGZILLA_XMLRPC_URL
     d = connect(**connect_args)
 
-    d.addCallback(get_summaries, matches, client, channel)
-    d.addErrback(send_err, client, channel)
-    # TODO: make this second callback not fire, if errback was called.
-    d.addCallback(send_message, client, channel, nick)
-    d.addErrback(send_err, client, channel)
+    (action, matches) = action_and_matches
+    for callback in action.callbacks:
+        d.addCallback(callback, matches, client, channel, nick)
+        d.addErrback(send_err, client, channel)
     raise ResponseNotReady
-
-
-@defer.inlineCallbacks
-def get_summaries(bz, matches, client, channel):
-    bugs = yield bz.get_bugs_summaries(matches)
-    defer.returnValue(bugs)
-
-
-def construct_message(bugs, nick):
-    """
-    Return a string about a nick and a list of tickets' URLs and summaries.
-    """
-    msgs = []
-    for bug in bugs:
-        if hasattr(settings, 'BUGZILLA_TICKET_URL'):
-            url = settings.BUGZILLA_TICKET_URL % {'ticket': bug.id}
-        else:
-            url = bug.weburl
-        msgs.append('%s [%s]' % (url, bug.summary))
-    if len(msgs) == 1:
-        msg = msgs[0]
-    else:
-        msg = "{} and {}".format(", ".join(msgs[:-1]), msgs[-1])
-    return '%s might be talking about %s' % (nick, msg)
-
-
-def send_message(bugs, client, channel, nick):
-    if bugs is not None:
-        msg = construct_message(bugs, nick)
-        client.msg(channel, msg)
 
 
 def send_err(e, client, channel):

--- a/helga_bugzilla/actions/describe.py
+++ b/helga_bugzilla/actions/describe.py
@@ -1,0 +1,66 @@
+import re
+from twisted.internet import defer
+from helga_bugzilla.utils import describe_bugs
+
+""" Match possible Bugzilla tickets, return links and summary info """
+
+
+def match(message):
+    """
+    Simple matching for "bz#123" comments.
+
+    returns: a (possibly empty) list of BZ IDs.
+    """
+    tickets = []
+    pattern = re.compile(r"""
+       (?:               # Prefix to trigger the plugin:
+            bzs?         #   "bz" or "bzs"
+          | bugs?        #   "bug" or "bugs"
+          | bugzilla?    #   "bugzilla" or "bugzillas"
+       )                 #
+       \s*               #
+       [#]?[0-9]+        # Number, optionally preceded by "#"
+       (?:               # The following pattern will match zero or more times:
+          ,?             #   Optional comma
+          \s+            #
+          (?:and\s+)?    #   Optional "and "
+          [#]?[0-9]+     #   Number, optionally preceded by "#"
+       )*
+       """, re.VERBOSE | re.IGNORECASE)
+    for bzmatch in re.findall(pattern, message):
+        for ticket in re.findall(r'[0-9]+', bzmatch):
+            if ticket == '2' and 'bz2' in bzmatch:
+                continue  # False positive, like ".tar.bz2".
+            if ticket not in tickets:
+                tickets.append(ticket)
+    return tickets
+
+
+@defer.inlineCallbacks
+def get_summaries(bz, matches, client, channel, nick):
+    """
+    Get all our bugs' summaries
+    """
+    bugs = yield bz.get_bugs_summaries(matches)
+    defer.returnValue(bugs)
+
+
+def send_message(bugs, matches, client, channel, nick):
+    """
+    Send a message to channel.
+    """
+    if bugs is not None:
+        msg = construct_message(bugs, nick)
+        client.msg(channel, msg)
+
+
+def construct_message(bugs, nick):
+    """
+    Return a string about a nick and a list of tickets' URLs and summaries.
+    """
+    description = describe_bugs(bugs)
+    return '%s might be talking about %s' % (nick, description)
+
+
+# List of callbacks to fire on a match:
+callbacks = (get_summaries, send_message)

--- a/helga_bugzilla/tests/test_describe.py
+++ b/helga_bugzilla/tests/test_describe.py
@@ -1,4 +1,6 @@
-from helga_bugzilla import match_tickets, construct_message, send_message
+from helga_bugzilla.actions.describe import match
+from helga_bugzilla.actions.describe import construct_message
+from helga_bugzilla.actions.describe import send_message
 import pytest
 from attrdict import AttrDict
 
@@ -55,23 +57,23 @@ class TestIsTicket(object):
 
     @pytest.mark.parametrize('line', line_matrix())
     def test_matches(self, line):
-        assert len(match_tickets(line)) > 0
+        assert len(match(line)) > 0
 
     @pytest.mark.parametrize('line', fail_line_matrix())
     def test_does_not_match(self, line):
-        assert match_tickets(line) == []
+        assert match(line) == []
 
     @pytest.mark.parametrize('line', multiple_ticket_lines)
     def test_matches_multiple_tickets(self, line):
-        assert match_tickets(line) == ['1', '2', '3']
+        assert match(line) == ['1', '2', '3']
 
     def test_ignore_bz2(self):
         line = 'please download the ceph.tar.bz2 file'
-        assert match_tickets(line) == []
+        assert match(line) == []
 
     def test_dedupe(self):
         line = 'bug 1 and bug 1'
-        assert match_tickets(line) == ['1']
+        assert match(line) == ['1']
 
 
 class FakeClient(object):
@@ -91,7 +93,7 @@ class TestSendMessage(object):
         channel = '#bots'
         nick = 'ktdreyer'
         # Send the message using our fake client
-        send_message([bug], client, channel, nick)
+        send_message([bug], ['bz#1'], client, channel, nick)
         expected = ('ktdreyer might be talking about '
                     'http://bz.example.com/1 [some issue subject]')
         assert client.last_message == (channel, expected)

--- a/helga_bugzilla/utils.py
+++ b/helga_bugzilla/utils.py
@@ -1,0 +1,18 @@
+from helga import settings
+
+
+def describe_bugs(bugs):
+    """
+    Return a string that describes a set of bugs (one, or more than one, etc)
+    """
+    msgs = []
+    for bug in bugs:
+        if hasattr(settings, 'BUGZILLA_TICKET_URL'):
+            url = settings.BUGZILLA_TICKET_URL % {'ticket': bug.id}
+        else:
+            url = bug.weburl
+        msgs.append('%s [%s]' % (url, bug.summary))
+    if len(msgs) == 1:
+        return msgs[0]
+    else:
+        return "{} and {}".format(", ".join(msgs[:-1]), msgs[-1])


### PR DESCRIPTION
Move the "describe a bug" action to a separate "actions.describe" library.

This will make room for us to implement additional actions.

Generalize the main helga_bugzilla() method so that each action passes a tuple of callback methods to call, rather than hard-coding the list of specific callback methods. This allows me to define completely separate
callbacks for each action.

Move the "describe_bugs()" method to a util lib, so this can be shared across actions.