### PR TITLE
setup.py: fix packaging after libs split

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 version = '1.1.0'
@@ -36,8 +36,7 @@ setup(name="helga-bugzilla",
       author_email='ktdreyer [at] ktdreyer [dot] com',
       url='https://github.com/ktdreyer/helga-bugzilla',
       license='MIT',
-      packages=find_packages(),
-      py_modules=['helga_bugzilla'],
+      packages=['helga_bugzilla'],
       install_requires=[
           'helga',
           'txbugzilla>=1.0.1',


### PR DESCRIPTION
setuptools was not properly discovering the plugin after the move from
helga_bugzilla.py to `helga_bugzilla/__init__.py` in
3d43d0c35f9fa18965f741a39d54b627b7d5333a