### PR TITLE
add external tracker searching

### DIFF
--- a/helga_bugzilla/__init__.py
+++ b/helga_bugzilla/__init__.py
@@ -1,13 +1,13 @@
 from txbugzilla import connect
 from helga.plugins import match, ResponseNotReady
 from helga import log, settings
-from helga_bugzilla.actions import describe
+from helga_bugzilla.actions import describe, search_external
 
 logger = log.getLogger(__name__)
 
 
 def match_bugzilla(message):
-    for action in (describe,):
+    for action in (describe, search_external):
         matches = action.match(message)
         if matches:
             return (action, matches)

--- a/helga_bugzilla/actions/search_external.py
+++ b/helga_bugzilla/actions/search_external.py
@@ -1,0 +1,131 @@
+import re
+from urlparse import urlparse
+from twisted.internet import defer
+from helga_bugzilla.utils import describe_bugs
+from helga_bugzilla.exceptions import UnknownTrackerError, NoBugFoundError
+from helga import log
+
+logger = log.getLogger(__name__)
+
+
+def match(message):
+    """
+    Match a comment asking about external trackers.
+    """
+    pattern = re.compile(r"""
+       (?:
+            which
+          | what
+          | whats
+          | whats\sthe
+          | what's
+          | what's\sthe
+          | what\sis
+          | what\sis\sthe
+          | where
+          | wheres
+          | wheres\sthe
+          | where's
+          | where's\sthe
+          | where\sis
+          | where\sis\sthe
+       )
+       \s+
+       (?:
+            bz
+          | bug
+          | rhbz
+          | bugzilla
+       )
+       \s+
+       (?:
+            is
+          | matches
+          | tracks
+          | corresponds\sto
+          | for
+          | that\sis
+          | that\smatches
+          | that\stracks
+          | that\scorresponds\sto
+       )
+       \s+
+       (\S+)
+       """, re.VERBOSE | re.IGNORECASE)
+    return [url.rstrip('?') for url in pattern.findall(message)]
+
+
+def find_tracker_url(ticket_url):
+    """
+    Given http://tracker.ceph.com/issues/16673 or
+    tracker.ceph.com/issues/16673, return "http://tracker.ceph.com".
+
+    Return None if ticket_url does not look like a URL.
+    """
+    if ticket_url.startswith('http://') or ticket_url.startswith('https://'):
+        o = urlparse(ticket_url)
+        scheme, netloc = o.scheme, o.netloc
+    else:
+        try:
+            (netloc, _) = ticket_url.split('/', 1)
+        except ValueError:
+            return None
+        if netloc == 'tracker.ceph.com':
+            scheme = 'http'
+        else:
+            scheme = 'https'
+    return '%s://%s' % (scheme, netloc)
+
+
+def find_tracker_id(ticket_url):
+    matches = None
+    if 'code.engineering.redhat.com' in ticket_url:
+        matches = re.findall('\d+$', ticket_url)
+    elif 'github.com' in ticket_url:
+        matches = re.findall('github\.com/(.+)', ticket_url)
+    elif 'launchpad.net' in ticket_url:
+        matches = re.findall('\d+$', ticket_url)
+    elif 'projects.engineering.redhat.com' in ticket_url:
+        regex = 'projects.engineering.redhat.com/browse/(.+)'
+        matches = re.findall(regex, ticket_url)
+    elif 'review.gerrithub.io' in ticket_url:
+        matches = re.findall('\d+$', ticket_url)
+    elif 'tracker.ceph.com' in ticket_url:
+        matches = re.findall('\d+$', ticket_url)
+    elif 'trello.com' in ticket_url:
+        matches = re.findall('trello\.com/c/([^/]+)', ticket_url)
+    if matches:
+        return matches[0]
+    raise UnknownTrackerError(ticket_url)
+
+
+@defer.inlineCallbacks
+def get_bz_for_externals(bz, links, client, channel, nick):
+    ticket_url = links[0]
+    external_tracker_url = find_tracker_url(ticket_url)
+    if external_tracker_url is None:
+        defer.returnValue(False)
+    external_tracker_id = find_tracker_id(ticket_url)
+    logger.debug('searching tracker: %s id: %s' % (external_tracker_url,
+                                                   external_tracker_id))
+    bugs = yield bz.find_by_external_tracker(external_tracker_url,
+                                             external_tracker_id)
+    defer.returnValue((ticket_url, bugs))
+
+
+def send_message(ticket_and_bugs, links, client, channel, nick):
+    # If we could figure out a ticket and list of bugs, then send a message.
+    if ticket_and_bugs:
+        (ticket, bugs) = ticket_and_bugs
+        msg = construct_message(ticket, bugs, nick)
+        client.msg(channel, msg)
+
+
+def construct_message(ticket, bugs, nick):
+    if bugs:
+        descriptions = describe_bugs(bugs)
+        return '%s, %s is %s' % (nick, ticket, descriptions)
+    raise NoBugFoundError(ticket, nick)
+
+
+callbacks = (get_bz_for_externals, send_message)

--- a/helga_bugzilla/exceptions.py
+++ b/helga_bugzilla/exceptions.py
@@ -1,0 +1,16 @@
+class HelgaBugzillaError(Exception):
+    pass
+
+
+class UnknownTrackerError(HelgaBugzillaError):
+    def __init__(self, ticket):
+        message = "I don't know how to parse %s for searching" % ticket
+        HelgaBugzillaError.__init__(self, message)
+
+
+class NoBugFoundError(HelgaBugzillaError):
+    def __init__(self, ticket, nick=None):
+        message = "I couldn't find a BZ for %s" % ticket
+        if nick is not None:
+            message = '%s, %s' % (nick, message)
+        HelgaBugzillaError.__init__(self, message)

--- a/helga_bugzilla/tests/test_search_external.py
+++ b/helga_bugzilla/tests/test_search_external.py
@@ -1,0 +1,128 @@
+from helga_bugzilla.actions.search_external import match
+from helga_bugzilla.actions.search_external import construct_message
+from helga_bugzilla.actions.search_external import send_message
+import pytest
+from attrdict import AttrDict
+
+
+def line_matrix():
+    # "what bz is tracker.ceph.com/issues/19055 ?"
+    # "what's the bz for tracker.ceph.com/issues/19055 ?"
+    phrase = '{question} {bug} {action} {external}'
+    questions = [
+        "which",
+        "what",
+        "whats the",
+        "what's the",
+        "what is the",
+        "wheres the",
+        "where's the",
+        "where is the",
+    ]
+    bugs = ['bz', 'bug', 'rhbz', 'bugzilla']
+    actions = [
+        'is',
+        'matches',
+        'tracks',
+        'corresponds to',
+        'for',
+        'that is',
+        'that matches',
+        'that tracks',
+        'that corresponds to',
+    ]
+    externals = ['tracker.ceph.com/issues/19055',
+                 'http://tracker.ceph.com/issues/19055']
+    lines = []
+    for question in questions:
+        for bug in bugs:
+            for action in actions:
+                for external in externals:
+                        line = phrase.format(question=question, bug=bug,
+                                             action=action, external=external)
+                        lines.append(line)
+    return lines
+
+
+class TestIsMatch(object):
+
+    @pytest.mark.parametrize('line', line_matrix())
+    def test_matches(self, line):
+        result = match(line)
+        assert len(result) > 0
+        assert 'tracker.ceph.com/issues/19055' in result[0]
+
+
+class TestConstructMessage(object):
+
+    def test_construct_message(self):
+        ticket = 'tracker.ceph.com/issues/19055'
+        bug = AttrDict({'summary': 'some issue subject',
+                        'weburl': 'http://bz.example.com/1'})
+        nick = 'ktdreyer'
+        result = construct_message(ticket, [bug], nick)
+        expected = ('ktdreyer, tracker.ceph.com/issues/19055 is '
+                    'http://bz.example.com/1 [some issue subject]')
+        assert result == expected
+
+
+class FakeClient(object):
+    """
+    Fake Helga client (eg IRC or XMPP) that simply saves the last
+    message sent.
+    """
+    def msg(self, channel, msg):
+        self.last_message = (channel, msg)
+
+
+class TestSendMessage(object):
+
+    def test_no_send_message(self):
+        client = FakeClient()
+        channel = '#bots'
+        send_message(False, [], client, channel, 'ktdreyer')
+        assert getattr(client, 'last_message', None) is None
+
+    def test_send_message(self):
+        ticket = 'tracker.ceph.com/issues/19055'
+        bugs = [AttrDict({'summary': 'some issue subject',
+                          'weburl': 'http://bz.example.com/1'})]
+        ticket_and_bugs = (ticket, bugs)
+        links = [ticket]
+        client = FakeClient()
+        channel = '#bots'
+        # Send the message using our fake client
+        send_message(ticket_and_bugs, links, client, channel, 'ktdreyer')
+        expected = ('ktdreyer, tracker.ceph.com/issues/19055 is '
+                    'http://bz.example.com/1 [some issue subject]')
+        assert client.last_message == (channel, expected)
+
+# I've commented out this test because it's unique to my workstation. I used it
+# to run through my entire IRC log history and spot-check that
+# search_external.py was only going to trigger on appropriate phrases. I don't
+# want our bot to fire on spurious comments about "what BZ ...". So far so
+# good.
+#
+#
+# def log_files():
+#     import os
+#     result = []
+#     logdir = '/home/kdreyer/.purple/logs'
+#     for root, dirs, files in os.walk(logdir):
+#         for logfile in files:
+#             if logfile.endswith('.txt'):
+#                 if 'ktdreyer@localhost' in root:
+#                     # Lots of false-positives here as I test things out
+#                     continue
+#                 result.append(os.path.join(root, logfile))
+#     return result
+#
+#
+# class TestLogs(object):
+#     @pytest.mark.parametrize('filename', log_files())
+#     def test_log(self, filename):
+#         result = []
+#         with open(filename, 'r') as logh:
+#             for line in logh:
+#                 result = match(line)
+#                 assert len(result) == 0, line

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name="helga-bugzilla",
       packages=['helga_bugzilla'],
       install_requires=[
           'helga',
-          'txbugzilla>=1.0.1',
+          'txbugzilla>=1.2.0',
       ],
       tests_require=[
           'pytest',


### PR DESCRIPTION
Use txbugzilla 1.2.0's new ability to search for BZs according to external trackers.

Add some common external trackers that we use in the Ceph team.

Add custom HelgaBugzilla exceptions for some cases. This lets us bubble up the error messages all the way to the Twisted errback, so helga will print the messages in the chat.