### PR TITLE
gracefully handle txbugzilla BugzillaExceptions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name="helga-bugzilla",
       packages=find_packages(),
       install_requires=[
           'helga',
-          'txbugzilla>=1.2.0',
+          'txbugzilla>=1.4.0',
       ],
       tests_require=[
           'pytest',


### PR DESCRIPTION
Prior to this change, we would print the server's XML-RPC message to the channel along with the final line of the backtrace.

Since these are "normal" errors, be a bit nicer about how we handle them:

- It's ok to print "Bug not found" messages.

- For "not authorized" errors, print the link with a "not authorized"
  explanation.

- For token problems, just log to Helga's log, rather than whining in
  the IRC channel where almost no one can fix it.

And for all of these, skip printing the backtrace.