### PR TITLE
skip bz strings in branch names and NVRs

### DIFF
--- a/helga_bugzilla/actions/describe.py
+++ b/helga_bugzilla/actions/describe.py
@@ -31,6 +31,9 @@ def match(message):
         if re.search(r'http\S+%s' % bzmatch, message):
             # Skip "bz" strings in URLs.
             continue
+        if '-%s' % bzmatch in message or '.%s' % bzmatch in message:
+            # Skip "-bz" or ".bz" strings (git branches or NVRs).
+            continue
         for ticket in re.findall(r'[0-9]+', bzmatch):
             if ticket == '2' and 'bz2' in bzmatch:
                 continue  # False positive, like ".tar.bz2".

--- a/helga_bugzilla/tests/test_describe.py
+++ b/helga_bugzilla/tests/test_describe.py
@@ -75,6 +75,14 @@ class TestIsTicket(object):
         line = 'please try http://example.com/package.bz1234.rpm'
         assert match(line) == []
 
+    def test_ignore_branch(self):
+        line = 'push your changes to ceph-1.3-rhel-patches-test-bz12345'
+        assert match(line) == []
+
+    def test_ignore_nvr(self):
+        line = 'the build NVR is 10.2.5-28.1.bz1445891redhat1xenial'
+        assert match(line) == []
+
     def test_dedupe(self):
         line = 'bug 1 and bug 1'
         assert match(line) == ['1']


### PR DESCRIPTION
We should not trigger on branch names or NVRs.